### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ Pings a host and returns the result.
 > [!NOTE]
 > This MCP server was made predominantly to [demonstrate](https://github.com/punkpeye/mcp-ping/blob/main/src/createServer.ts) how to use [FastMCP](https://github.com/punkpeye/fastmcp).
 
+<a href="https://glama.ai/mcp/servers/@punkpeye/mcp-ping">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@punkpeye/mcp-ping/badge" alt="mcp-ping MCP server" />
+</a>
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
This PR adds a badge for the [mcp-ping](https://glama.ai/mcp/servers/@punkpeye/mcp-ping) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@punkpeye/mcp-ping">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@punkpeye/mcp-ping/badge" alt="mcp-ping MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.